### PR TITLE
feat: Refactor AuthScreen and ForgotPasswordScreen UI

### DIFF
--- a/lib/feature/auth/forgot-password/ui/forgot_password_screen.dart
+++ b/lib/feature/auth/forgot-password/ui/forgot_password_screen.dart
@@ -49,7 +49,6 @@ class ForgotPasswordScreen extends StatelessWidget {
                     ),
                   ),
                 ),
-                spacingV(120.h),
               ],
             ),
           ),

--- a/lib/feature/auth/ui/view/auth_screen.dart
+++ b/lib/feature/auth/ui/view/auth_screen.dart
@@ -24,7 +24,12 @@ class AuthScreen extends StatelessWidget {
             return Stack(
               children: [
                 Positioned(
-                  top: 250,
+                  top: 0,
+                  right: 0,
+                  child: SvgPicture.asset(R.images.appLogoFram39),
+                ),
+                Positioned(
+                  top: MediaQuery.of(context).size.height * 0.3,
                   left: 0,
                   child: SvgPicture.asset(R.images.appLogoFram40),
                 ),
@@ -48,20 +53,25 @@ class AuthScreen extends StatelessWidget {
                             },
                           ),
 
-                          Container(
-                            alignment: Alignment.bottomLeft,
-                            decoration: BoxDecoration(
-                              color: R.colors.whiteLight,
-                              borderRadius: BorderRadius.only(
-                                topLeft: Radius.circular(30.r),
-                                topRight: Radius.circular(30.r),
-                              ),
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.only(bottom: 20),
-                              child: BlocBuilder<AuthCubit, AuthState>(
-                                builder: (context, state) {
-                                  return Column(
+                          BlocBuilder<AuthCubit, AuthState>(
+                            builder: (context, state) {
+                              return Container(
+                                height:
+                                    state == AuthState.forgotPassword
+                                        ? MediaQuery.of(context).size.height *
+                                            0.6
+                                        : null,
+                                alignment: Alignment.bottomLeft,
+                                decoration: BoxDecoration(
+                                  color: R.colors.whiteLight,
+                                  borderRadius: BorderRadius.only(
+                                    topLeft: Radius.circular(30.r),
+                                    topRight: Radius.circular(30.r),
+                                  ),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.only(bottom: 20),
+                                  child: Column(
                                     children: [
                                       spacingV(20.h),
                                       state == AuthState.forgotPassword
@@ -76,22 +86,20 @@ class AuthScreen extends StatelessWidget {
                                       if (state == AuthState.register)
                                         RegisterFormScreen(),
                                       if (state == AuthState.forgotPassword)
-                                        ForgotPasswordScreen(),
+                                        Align(
+                                          alignment: Alignment.topCenter,
+                                          child: ForgotPasswordScreen(),
+                                        ),
                                     ],
-                                  );
-                                },
-                              ),
-                            ),
+                                  ),
+                                ),
+                              );
+                            },
                           ),
                         ],
                       ),
                     ),
                   ),
-                ),
-                Positioned(
-                  top: 0,
-                  right: 0,
-                  child: SvgPicture.asset(R.images.appLogoFram39),
                 ),
               ],
             );


### PR DESCRIPTION
This commit refactors the UI of the AuthScreen and ForgotPasswordScreen to improve layout and responsiveness.

The following changes were made:

- Moved app logo to be positioned at the top right of the AuthScreen.
- Adjusted the positioning of the second logo on the AuthScreen to be responsive to screen size.
- Wrapped the content of the AuthScreen in a BlocBuilder to dynamically adjust the height of the white container based on the current authentication state (forgot password).
- Removed unnecessary vertical spacing from the ForgotPasswordScreen.
- Aligned the ForgotPasswordScreen to the top center within the AuthScreen when in the forgot password state.