### PR TITLE
feat: Integrate url_launcher plugin and implement social media link f…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="Mzaodin"
         android:name="${applicationName}"
@@ -40,6 +41,20 @@
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
+        </intent>
+         <!-- If your app checks for SMS support -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="sms" />
+        </intent>
+        <!-- If your app checks for call support -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="tel" />
+        </intent>
+        <!-- If your application checks for inAppBrowserView launch mode support -->
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
         </intent>
     </queries>
 </manifest>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -29,6 +29,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
@@ -37,6 +39,7 @@ DEPENDENCIES:
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -58,6 +61,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
@@ -70,6 +75,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,6 +41,14 @@
 			<string>UIInterfaceOrientationLandscapeLeft</string>
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>
+		<key>LSApplicationQueriesSchemes</key>
+		<array>
+			<string>http</string>
+			<string>https</string>
+			<string>mailto</string>
+  			<string>sms</string>
+  			<string>tel</string>
+		</array>
 		<key>CADisableMinimumFrameDurationOnPhone</key>
 		<true/>
 		<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/lib/feature/profile/view/profile_screen.dart
+++ b/lib/feature/profile/view/profile_screen.dart
@@ -5,6 +5,7 @@ import 'package:mzaodina_app/core/resources/resources.dart';
 import 'package:mzaodina_app/core/router/app_routes.dart';
 import 'package:mzaodina_app/core/widgets/custom_elevated_button.dart';
 import 'package:mzaodina_app/feature/profile/view/widget/custom_account_list_tile.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -237,7 +238,22 @@ class ProfileScreen extends StatelessWidget {
                   Row(
                     children: [
                       InkWell(
-                        onTap: () => debugPrint('تواصل معنا على تويتر'),
+                        onTap: () async {
+                          if (await canLaunchUrl(
+                            Uri.parse('https://x.com/Mzaodin'),
+                          )) {
+                            // Check if the URL can be launched
+                            await launchUrl(
+                              Uri.parse('https://x.com/Mzaodin'),
+                              mode: LaunchMode.externalApplication,
+                            ); // Launch the URL
+                          } else {
+                            // Handle the error if the URL cannot be launched
+                            debugPrint('Could not launch URL');
+                            SnackBar(content: Text('Could not launch URL'));
+                            // throw 'Could not launch'; // throw could be used to handle erroneous situations
+                          }
+                        },
                         child: SvgPicture.asset(
                           R.images.xIcon,
                           width: 25.w,
@@ -246,8 +262,22 @@ class ProfileScreen extends StatelessWidget {
                       ),
                       SizedBox(width: 18.h),
                       InkWell(
-                        onTap: () => debugPrint('تواصل معنا على تويتر'),
-
+                        onTap: () async {
+                          if (await canLaunchUrl(
+                            Uri.parse('https://www.tiktok.com/@mzaodin'),
+                          )) {
+                            // Check if the URL can be launched
+                            await launchUrl(
+                              Uri.parse('https://www.tiktok.com/@mzaodin'),
+                              mode: LaunchMode.externalApplication,
+                            ); // Launch the URL
+                          } else {
+                            // Handle the error if the URL cannot be launched
+                            debugPrint('Could not launch URL');
+                            SnackBar(content: Text('Could not launch URL'));
+                            // throw 'Could not launch'; // throw could be used to handle erroneous situations
+                          }
+                        },
                         child: SvgPicture.asset(
                           R.images.tiktokIcon,
                           width: 25.w,
@@ -256,18 +286,51 @@ class ProfileScreen extends StatelessWidget {
                       ),
                       SizedBox(width: 18.h),
                       InkWell(
-                        onTap: () => debugPrint('تواصل معنا على تويتر'),
-
+                        onTap: () async {
+                          if (await canLaunchUrl(
+                            Uri.parse(
+                              'https://www.instagram.com/mzaodin/?hl=ar',
+                            ),
+                          )) {
+                            // Check if the URL can be launched
+                            await launchUrl(
+                              Uri.parse(
+                                'https://www.instagram.com/mzaodin/?hl=ar',
+                              ),
+                              mode: LaunchMode.externalApplication,
+                            ); // Launch the URL
+                          } else {
+                            // Handle the error if the URL cannot be launched
+                            debugPrint('Could not launch URL');
+                            SnackBar(content: Text('Could not launch URL'));
+                            // throw 'Could not launch'; // throw could be used to handle erroneous situations
+                          }
+                        },
                         child: SvgPicture.asset(
                           R.images.instaIcon,
                           width: 25.w,
                           height: 25.h,
                         ),
                       ),
+
                       SizedBox(width: 18.h),
                       InkWell(
-                        onTap: () => debugPrint('تواصل معنا على تويتر'),
-
+                        onTap: () async {
+                          if (await canLaunchUrl(
+                            Uri.parse('https://www.snapchat.com/add/mzaodin'),
+                          )) {
+                            // Check if the URL can be launched
+                            await launchUrl(
+                              Uri.parse('https://www.snapchat.com/add/mzaodin'),
+                              mode: LaunchMode.externalApplication,
+                            ); // Launch the URL
+                          } else {
+                            // Handle the error if the URL cannot be launched
+                            debugPrint('Could not launch URL');
+                            SnackBar(content: Text('Could not launch URL'));
+                            // throw 'Could not launch'; // throw could be used to handle erroneous situations
+                          }
+                        },
                         child: SvgPicture.asset(
                           R.images.snapIcon,
                           width: 25.w,
@@ -277,8 +340,22 @@ class ProfileScreen extends StatelessWidget {
                       Spacer(),
 
                       InkWell(
-                        onTap: () => debugPrint('تواصل معنا على تويتر'),
-
+                        // onTap: () {
+                        //   if (await canLaunchUrl(
+                        //     Uri.parse('https://www.instagram.com/'),
+                        //   )) {
+                        //     // Check if the URL can be launched
+                        //     await launchUrl(
+                        //       Uri.parse('https://www.tiktok.com/@mzaodin'),
+                        //       mode: LaunchMode.externalApplication,
+                        //     ); // Launch the URL
+                        //   } else {
+                        //     // Handle the error if the URL cannot be launched
+                        //     debugPrint('Could not launch URL');
+                        //     SnackBar(content: Text('Could not launch URL'));
+                        //     // throw 'Could not launch'; // throw could be used to handle erroneous situations
+                        //   }
+                        // },
                         child: Container(
                           width: 136.w,
                           decoration: BoxDecoration(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_localization/flutter_localization_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_localization_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterLocalizationPlugin");
   flutter_localization_plugin_register_with_registrar(flutter_localization_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_localization
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,10 +9,12 @@ import firebase_core
 import flutter_localization
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FlutterLocalizationPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalizationPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -626,6 +626,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   country_picker: ^2.0.27
   google_fonts: ^6.2.1
   firebase_core: ^3.13.0
+  url_launcher: ^6.3.1
 
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_localization/flutter_localization_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FlutterLocalizationPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterLocalizationPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   flutter_localization
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
…unctionality

This commit integrates the `url_launcher` plugin to enable the app to open URLs in external applications. It also implements the functionality to launch social media links (Twitter, TikTok, Instagram, and Snapchat) from the profile screen.

The following changes were made:

- Added the `url_launcher` dependency to `pubspec.yaml` and updated `pubspec.lock`.
- Updated `linux/flutter/generated_plugins.cmake`, `windows/flutter/generated_plugins.cmake`, `windows/flutter/generated_plugin_registrant.cc`, `macos/Flutter/GeneratedPluginRegistrant.swift`, and `linux/flutter/generated_plugin_registrant.cc` to register the `url_launcher` plugin for different platforms.
- Added `LSApplicationQueriesSchemes` to `ios/Runner/Info.plist` to allow the app to query for URL schemes like `http`, `https`, `mailto`, `sms`, and `tel`.
- Added `<uses-permission android:name="android.permission.INTERNET"/>` and intents for SMS, call, and inAppBrowserView support to `android/app/src/main/AndroidManifest.xml`.
- Updated `lib/feature/profile/view/profile_screen.dart` to use `url_launcher` to open social media links in external applications. The code checks if the URL can be launched before attempting to launch it, and displays an error message if it cannot.
- Updated `ios/Podfile.lock` to reflect the added `url_launcher_ios` dependency.