### PR TITLE
fix: Resolve auction details and registration issues

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - Flutter
   - Firebase/CoreOnly (11.10.0):
     - FirebaseCore (~> 11.10.0)
-  - firebase_core (3.13.0):
+  - firebase_core (3.13.1):
     - Firebase/CoreOnly (= 11.10.0)
     - Flutter
   - FirebaseCore (11.10.0):
@@ -121,7 +121,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
   Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
-  firebase_core: 432718558359a8c08762151b5f49bb0f093eb6e0
+  firebase_core: 3c2f323cae65c97a636a05a23b17730ef93df2cf
   FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
   FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7

--- a/lib/core/router/route.dart
+++ b/lib/core/router/route.dart
@@ -15,7 +15,6 @@ import 'package:mzaodina_app/feature/home/home_details/muntahi/data/model/muntah
 import 'package:mzaodina_app/feature/home/home_details/muntahi/ui/view/home_details_muntahi_screen.dart';
 import 'package:mzaodina_app/feature/home/home_details/qadim/data/model/qadim_auction_response.dart';
 import 'package:mzaodina_app/feature/home/home_details/qadim/ui/view/home_details_qadim_screen.dart';
-import 'package:mzaodina_app/feature/home/home_details/qadim/ui/view_model/register_to_auction_cubit/register_to_auction_cubit.dart';
 import 'package:mzaodina_app/feature/home/home_details/sayantaliq/ui/view/home_details_sayantaliq_screen.dart';
 import 'package:mzaodina_app/feature/home/home_details/ui/view_model/cubit/show_action_cubit.dart';
 import 'package:mzaodina_app/feature/home/join-auction/view/join_the_auction.dart';
@@ -50,20 +49,11 @@ class AppRouter {
         final args = settings.arguments as QadimAuction;
         return MaterialPageRoute(
           builder:
-              (_) => MultiBlocProvider(
-                providers: [
-                  BlocProvider(
-                    create:
-                        (context) =>
-                            getIt<ShowActionCubit>()..getShowAction(args.slug),
-                  ),
-                  BlocProvider(
-                    create:
-                        (context) =>
-                            getIt<RegisterToAuctionCubit>()
-                              ..registerToAuction(args.slug),
-                  ),
-                ],
+              (_) => BlocProvider(
+                create:
+                    (context) =>
+                        getIt<ShowActionCubit>()..getShowAction(args.slug),
+
                 child: HomeDetailsQadimScreen(qadimDetails: args),
               ),
         );

--- a/lib/feature/home/home_details/data/model/show_action_model.dart
+++ b/lib/feature/home/home_details/data/model/show_action_model.dart
@@ -43,7 +43,7 @@ class Auction {
   final int registrationAmount;
 
   @JsonKey(name: 'auction_duration_minutes')
-  final int auctionDurationMinutes;
+  final int? auctionDurationMinutes;
 
   @JsonKey(name: 'auction_start_rate')
   final int auctionStartRate;

--- a/lib/feature/home/home_details/data/model/show_action_model.g.dart
+++ b/lib/feature/home/home_details/data/model/show_action_model.g.dart
@@ -30,7 +30,7 @@ Auction _$AuctionFromJson(Map<String, dynamic> json) => Auction(
   currentBidders: (json['current_bidders'] as num).toInt(),
   isRegister: json['isRegister'] as bool,
   registrationAmount: (json['registration_amount'] as num).toInt(),
-  auctionDurationMinutes: (json['auction_duration_minutes'] as num).toInt(),
+  auctionDurationMinutes: (json['auction_duration_minutes'] as num?)?.toInt(),
   auctionStartRate: (json['auction_start_rate'] as num).toInt(),
   productSku: json['product_sku'] as String,
   product: Product.fromJson(json['product'] as Map<String, dynamic>),

--- a/lib/feature/home/home_details/muntahi/ui/view/home_details_muntahi_screen.dart
+++ b/lib/feature/home/home_details/muntahi/ui/view/home_details_muntahi_screen.dart
@@ -99,7 +99,7 @@ class HomeDetailsMuntahiScreen extends StatelessWidget {
                         ),
                         Spacer(),
                         Text(
-                          muntahiDetails.winner?.user.username ?? 'لايوجد',
+                          muntahiDetails.winner.user.username,
                           style: R.textStyles.font12primaryW600Light,
                         ),
                       ],

--- a/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.dart
+++ b/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.dart
@@ -35,7 +35,7 @@ class QadimAuction {
   final int registrationAmount;
 
   @JsonKey(name: 'auction_duration_minutes')
-  final int auctionDurationMinutes;
+  final int? auctionDurationMinutes;
 
   @JsonKey(name: 'auction_start_rate')
   final int auctionStartRate;

--- a/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.g.dart
+++ b/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.g.dart
@@ -32,7 +32,7 @@ QadimAuction _$QadimAuctionFromJson(Map<String, dynamic> json) => QadimAuction(
   openingAmount: (json['opening_amount'] as num).toInt(),
   requiredBidders: (json['required_bidders'] as num).toInt(),
   registrationAmount: (json['registration_amount'] as num).toInt(),
-  auctionDurationMinutes: (json['auction_duration_minutes'] as num).toInt(),
+  auctionDurationMinutes: (json['auction_duration_minutes'] as num?)?.toInt(),
   auctionStartRate: (json['auction_start_rate'] as num).toInt(),
   productSku: json['product_sku'] as String,
   isRegister: json['isRegister'] as bool,

--- a/lib/feature/home/home_details/qadim/ui/view/widget/custom_qadim_card_view_item.dart
+++ b/lib/feature/home/home_details/qadim/ui/view/widget/custom_qadim_card_view_item.dart
@@ -12,8 +12,8 @@ import 'package:mzaodina_app/feature/home/ui/view/widget/custom_indcator_item.da
 import 'package:share_plus/share_plus.dart';
 
 class CustomQadimCardViewItem extends StatefulWidget {
-  const CustomQadimCardViewItem({super.key, required this.qadinDataModel});
-  final QadimAuction qadinDataModel;
+  const CustomQadimCardViewItem({super.key, required this.qadimDataModel});
+  final QadimAuction qadimDataModel;
   @override
   State<CustomQadimCardViewItem> createState() =>
       _CustomQadimCardViewItemState();
@@ -23,7 +23,7 @@ class _CustomQadimCardViewItemState extends State<CustomQadimCardViewItem> {
   @override
   Widget build(BuildContext context) {
     final eventTimeFromApi = DateTime.now().add(
-      Duration(minutes: widget.qadinDataModel.auctionDurationMinutes),
+      Duration(minutes: widget.qadimDataModel.auctionDurationMinutes ?? 0),
     );
 
     return SingleChildScrollView(
@@ -45,9 +45,9 @@ class _CustomQadimCardViewItemState extends State<CustomQadimCardViewItem> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Hero(
-                      tag: widget.qadinDataModel.slug,
+                      tag: widget.qadimDataModel.slug,
                       child: CachedNetworkImage(
-                        imageUrl: widget.qadinDataModel.product.images[0],
+                        imageUrl: widget.qadimDataModel.product.images[0],
                         width: 120.w,
                         height: 158.h,
                         fit: BoxFit.cover,
@@ -67,7 +67,7 @@ class _CustomQadimCardViewItemState extends State<CustomQadimCardViewItem> {
                           Container(
                             padding: EdgeInsets.symmetric(vertical: 8.h),
                             child: Text(
-                              widget.qadinDataModel.product.nameAr,
+                              widget.qadimDataModel.product.nameAr,
                               style: R.textStyles.font16BlackW500Light,
                             ),
                           ),
@@ -81,12 +81,12 @@ class _CustomQadimCardViewItemState extends State<CustomQadimCardViewItem> {
                           CoustomRowItem(
                             title: 'السعر بالأسواق',
                             price:
-                                widget.qadinDataModel.product.price.toString(),
+                                widget.qadimDataModel.product.price.toString(),
                           ),
                           CoustomRowItem(
                             title: 'بداية المزاد',
                             price:
-                                widget.qadinDataModel.product.price.toString(),
+                                widget.qadimDataModel.product.price.toString(),
                           ),
 
                           CustomIndcatorItem(
@@ -109,7 +109,7 @@ class _CustomQadimCardViewItemState extends State<CustomQadimCardViewItem> {
                           Navigator.pushNamed(
                             context,
                             AppRoutes.homeDetailsQadimScreenRoute,
-                            arguments: widget.qadinDataModel,
+                            arguments: widget.qadimDataModel,
                           );
                         },
                         backgroundColor: R.colors.primaryColorLight,

--- a/lib/feature/home/home_details/qadim/ui/view/widget/custom_verification_to_register_auction_botton.dart
+++ b/lib/feature/home/home_details/qadim/ui/view/widget/custom_verification_to_register_auction_botton.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mzaodina_app/core/DI/setup_get_it.dart';
 import 'package:mzaodina_app/core/helper/user_session.dart';
 import 'package:mzaodina_app/core/router/app_routes.dart';
 import 'package:mzaodina_app/core/widgets/custom_dialog_widget.dart';
 import 'package:mzaodina_app/core/widgets/custom_elevated_button.dart';
 import 'package:mzaodina_app/feature/home/home_details/qadim/ui/view/widget/auction_register_button.dart';
+import 'package:mzaodina_app/feature/home/home_details/qadim/ui/view_model/register_to_auction_cubit/register_to_auction_cubit.dart';
 import 'package:mzaodina_app/feature/home/home_details/ui/view_model/cubit/show_action_cubit.dart';
 
 class CustomVerificationToRegisterAuctionBotton extends StatelessWidget {
@@ -69,7 +71,15 @@ class CustomVerificationToRegisterAuctionBotton extends StatelessWidget {
                   onPressed: () {},
                 );
               } else if (state is ShowActionSuccess) {
-                return AuctionRegisterButton(auction: state.showActionModel, );
+                return BlocProvider<RegisterToAuctionCubit>(
+                  create: (context) => getIt<RegisterToAuctionCubit>(),
+                  child: AuctionRegisterButton(
+                    auction: state.showActionModel,
+                    onRegistered: () {
+                      context.read<ShowActionCubit>().getShowAction(slug);
+                    },
+                  ),
+                );
               } else if (state is ShowActionError) {
                 return CustomElevatedButton(
                   text: 'إعادة التحميل',

--- a/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.dart
+++ b/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.dart
@@ -32,7 +32,7 @@ class SayantaliqAuction {
   @JsonKey(name: 'registration_amount')
   final int registrationAmount;
   @JsonKey(name: 'auction_duration_minutes')
-  final int auctionDurationMinutes;
+  final int? auctionDurationMinutes;
   @JsonKey(name: 'auction_start_rate')
   final int auctionStartRate;
   @JsonKey(name: 'product_sku')

--- a/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.g.dart
+++ b/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.g.dart
@@ -33,7 +33,8 @@ SayantaliqAuction _$SayantaliqAuctionFromJson(Map<String, dynamic> json) =>
       openingAmount: (json['opening_amount'] as num).toInt(),
       requiredBidders: (json['required_bidders'] as num).toInt(),
       registrationAmount: (json['registration_amount'] as num).toInt(),
-      auctionDurationMinutes: (json['auction_duration_minutes'] as num).toInt(),
+      auctionDurationMinutes:
+          (json['auction_duration_minutes'] as num?)?.toInt(),
       auctionStartRate: (json['auction_start_rate'] as num).toInt(),
       productSku: json['product_sku'] as String,
       isRegister: json['isRegister'] as bool,

--- a/lib/feature/home/ui/view/widget/custom_tap_view.dart
+++ b/lib/feature/home/ui/view/widget/custom_tap_view.dart
@@ -112,7 +112,7 @@ class _CustomTapViewState extends State<CustomTapView>
                             return Padding(
                               padding: const EdgeInsets.only(bottom: 16.0),
                               child: CustomQadimCardViewItem(
-                                qadinDataModel:
+                                qadimDataModel:
                                     qadimAuctionResponse.data[index],
                               ),
                             );

--- a/lib/feature/profile/view/widget/custom_user_data_details_section.dart
+++ b/lib/feature/profile/view/widget/custom_user_data_details_section.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mzaodina_app/core/resources/resources.dart';
 import 'package:mzaodina_app/core/router/app_routes.dart';
-import 'package:mzaodina_app/feature/auth/register/ui/view_model/country_cubit/country_cubit.dart';
 import 'package:mzaodina_app/feature/profile/view/widget/custom_account_list_tile.dart';
 
 class CustomUserDataDetailsSection extends StatelessWidget {


### PR DESCRIPTION
This commit addresses several issues related to auction details and registration:

- **Nullable auction duration:** Made `auctionDurationMinutes` nullable in `ShowActionModel`, `QadimAuctionResponse`, and `SayantaliqAuctionResponse` models to handle cases where the duration might be missing.
- **Muntahi winner username:** Fixed a null safety issue in `HomeDetailsMuntahiScreen` when displaying the winner's username.
- **Qadim auction registration:**
    - Removed the `RegisterToAuctionCubit` from the `HomeDetailsQadimScreen` route to avoid unnecessary initialization.
    - Moved the `RegisterToAuctionCubit` to `CustomVerificationToRegisterAuctionBotton` to manage the registration state locally.
    - Added a callback function `onRegistered` to `AuctionRegisterButton` to refresh the auction details after successful registration.
    - Displayed a snackbar message upon successful or failed registration.
- **Qadim card view item:** Fixed a typo in `CustomQadimCardViewItem` and passed the `qadimDataModel` to the `HomeDetailsQadimScreen` route.
- **Firebase core version:** Updated the `firebase_core` version in `Podfile.lock` from 3.13.0 to 3.13.1.
- **Removed unused import:** Removed unused import in `CustomUserDataDetailsSection`.