### PR TITLE
feat: Display loading dialog during Google and Apple sign-in

### DIFF
--- a/lib/feature/auth/apple/view/sign_in_with_apple.dart
+++ b/lib/feature/auth/apple/view/sign_in_with_apple.dart
@@ -31,6 +31,21 @@ Future<void> signInWithApple(context) async {
     log('email: $email');
 
     final appleCubit = AppleCubit(AppleRepo(getIt<ApiService>()));
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          content: Row(
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(width: 20),
+              Text('جاري تسجيل الدخول...'),
+            ],
+          ),
+        );
+      },
+    );
     await appleCubit.login({
       "token": identityToken,
       // "authorizationCode": authorizationCode,
@@ -38,7 +53,7 @@ Future<void> signInWithApple(context) async {
       "name": name,
       // "email": email,
     });
-
+    Navigator.of(context).pop(); // Close the loading dialog
     Navigator.pushNamedAndRemoveUntil(
       context,
       AppRoutes.navBarRoute,

--- a/lib/feature/auth/google/sign_in_with_google.dart
+++ b/lib/feature/auth/google/sign_in_with_google.dart
@@ -12,7 +12,7 @@ final GoogleSignIn _googleSignIn = GoogleSignIn(
   clientId:
       Platform.isIOS
           ? '412322100407-a58r9tpblb2dp6l0at9scou4nm6jv6mm.apps.googleusercontent.com'
-          : '412322100407-0rnuit2t6n43g0enmnk4dmbhks76b7gv.apps.googleusercontent.com',
+          : null,
   scopes: ['email', 'profile'],
 );
 
@@ -36,13 +36,29 @@ Future<void> loginWithGoogle(context) async {
     // log('Access Token: $accessToken');
 
     final googleCubit = GoogleCubit(GoogleRepo(getIt<ApiService>()));
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          content: Row(
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(width: 20),
+              Text('جاري تسجيل الدخول...'),
+            ],
+          ),
+        );
+      },
+    );
     await googleCubit.login({"token": idToken});
-
+    Navigator.of(context).pop(); // Close the loading dialog
     Navigator.pushNamedAndRemoveUntil(
       context,
       AppRoutes.navBarRoute,
       (Route<dynamic> route) => false,
     );
+    log('تم تسجيل الدخول بنجاح');
   } catch (e) {
     log("خطأ أثناء تسجيل الدخول: $e");
     ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
- Added a loading dialog to improve user experience during Google and Apple sign-in processes.
- The dialog displays a circular progress indicator and a "جاري تسجيل الدخول..." message.
- The dialog is shown before the API call and dismissed after the call completes.
- Removed the iOS-specific client ID from the Google Sign-In configuration, as it's not needed when using the universal link.