### PR TITLE
feat: Enhance home screen data handling and error management

### DIFF
--- a/lib/feature/home/home_details/jaraa/data/model/jaraa_auction_response.dart
+++ b/lib/feature/home/home_details/jaraa/data/model/jaraa_auction_response.dart
@@ -6,7 +6,7 @@ part 'jaraa_auction_response.g.dart';
 class JaraaAuctionResponse {
   final bool status;
   final String message;
-  final List<JaraaAuction> data;
+  final Data data;
 
   JaraaAuctionResponse({
     required this.status,
@@ -18,6 +18,30 @@ class JaraaAuctionResponse {
       _$JaraaAuctionResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$JaraaAuctionResponseToJson(this);
+}
+
+@JsonSerializable()
+class Data {
+  final List<JaraaAuction> auctions;
+  final int? total;
+  @JsonKey(name: 'current_page')
+  final int? currentPage;
+  @JsonKey(name: 'last_page')
+  final int? lastPage;
+  @JsonKey(name: 'next_page_url')
+  final String? nextPageUrl;
+  @JsonKey(name: 'prev_page_url')
+  final String? prevPageUrl;
+  Data({
+    required this.auctions,
+    this.total,
+    this.currentPage,
+    this.lastPage,
+    this.nextPageUrl,
+    this.prevPageUrl,
+  });
+  factory Data.fromJson(Map<String, dynamic> json) => _$DataFromJson(json);
+  Map<String, dynamic> toJson() => _$DataToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)

--- a/lib/feature/home/home_details/jaraa/data/model/jaraa_auction_response.g.dart
+++ b/lib/feature/home/home_details/jaraa/data/model/jaraa_auction_response.g.dart
@@ -11,10 +11,7 @@ JaraaAuctionResponse _$JaraaAuctionResponseFromJson(
 ) => JaraaAuctionResponse(
   status: json['status'] as bool,
   message: json['message'] as String,
-  data:
-      (json['data'] as List<dynamic>)
-          .map((e) => JaraaAuction.fromJson(e as Map<String, dynamic>))
-          .toList(),
+  data: Data.fromJson(json['data'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$JaraaAuctionResponseToJson(
@@ -22,7 +19,28 @@ Map<String, dynamic> _$JaraaAuctionResponseToJson(
 ) => <String, dynamic>{
   'status': instance.status,
   'message': instance.message,
-  'data': instance.data.map((e) => e.toJson()).toList(),
+  'data': instance.data.toJson(),
+};
+
+Data _$DataFromJson(Map<String, dynamic> json) => Data(
+  auctions:
+      (json['auctions'] as List<dynamic>)
+          .map((e) => JaraaAuction.fromJson(e as Map<String, dynamic>))
+          .toList(),
+  total: (json['total'] as num?)?.toInt(),
+  currentPage: (json['current_page'] as num?)?.toInt(),
+  lastPage: (json['last_page'] as num?)?.toInt(),
+  nextPageUrl: json['next_page_url'] as String?,
+  prevPageUrl: json['prev_page_url'] as String?,
+);
+
+Map<String, dynamic> _$DataToJson(Data instance) => <String, dynamic>{
+  'auctions': instance.auctions,
+  'total': instance.total,
+  'current_page': instance.currentPage,
+  'last_page': instance.lastPage,
+  'next_page_url': instance.nextPageUrl,
+  'prev_page_url': instance.prevPageUrl,
 };
 
 JaraaAuction _$JaraaAuctionFromJson(Map<String, dynamic> json) => JaraaAuction(

--- a/lib/feature/home/home_details/muntahi/data/model/muntahi_auctions_response.dart
+++ b/lib/feature/home/home_details/muntahi/data/model/muntahi_auctions_response.dart
@@ -6,7 +6,7 @@ part 'muntahi_auctions_response.g.dart';
 class MuntahiAuctionsResponse {
   final bool status;
   final String message;
-  final List<MuntahiAction> data;
+  final Data data;
 
   MuntahiAuctionsResponse({
     required this.status,
@@ -17,6 +17,30 @@ class MuntahiAuctionsResponse {
   factory MuntahiAuctionsResponse.fromJson(Map<String, dynamic> json) =>
       _$MuntahiAuctionsResponseFromJson(json);
   Map<String, dynamic> toJson() => _$MuntahiAuctionsResponseToJson(this);
+}
+
+@JsonSerializable()
+class Data {
+  final List<MuntahiAction> auctions;
+  final int? total;
+  @JsonKey(name: 'current_page')
+  final int? currentPage;
+  @JsonKey(name: 'last_page')
+  final int? lastPage;
+  @JsonKey(name: 'next_page_url')
+  final String? nextPageUrl;
+  @JsonKey(name: 'prev_page_url')
+  final String? prevPageUrl;
+  Data({
+    required this.auctions,
+    this.total,
+    this.currentPage,
+    this.lastPage,
+    this.nextPageUrl,
+    this.prevPageUrl,
+  });
+  factory Data.fromJson(Map<String, dynamic> json) => _$DataFromJson(json);
+  Map<String, dynamic> toJson() => _$DataToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true)

--- a/lib/feature/home/home_details/muntahi/data/model/muntahi_auctions_response.g.dart
+++ b/lib/feature/home/home_details/muntahi/data/model/muntahi_auctions_response.g.dart
@@ -11,10 +11,7 @@ MuntahiAuctionsResponse _$MuntahiAuctionsResponseFromJson(
 ) => MuntahiAuctionsResponse(
   status: json['status'] as bool,
   message: json['message'] as String,
-  data:
-      (json['data'] as List<dynamic>)
-          .map((e) => MuntahiAction.fromJson(e as Map<String, dynamic>))
-          .toList(),
+  data: Data.fromJson(json['data'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$MuntahiAuctionsResponseToJson(
@@ -22,7 +19,28 @@ Map<String, dynamic> _$MuntahiAuctionsResponseToJson(
 ) => <String, dynamic>{
   'status': instance.status,
   'message': instance.message,
-  'data': instance.data.map((e) => e.toJson()).toList(),
+  'data': instance.data.toJson(),
+};
+
+Data _$DataFromJson(Map<String, dynamic> json) => Data(
+  auctions:
+      (json['auctions'] as List<dynamic>)
+          .map((e) => MuntahiAction.fromJson(e as Map<String, dynamic>))
+          .toList(),
+  total: (json['total'] as num?)?.toInt(),
+  currentPage: (json['current_page'] as num?)?.toInt(),
+  lastPage: (json['last_page'] as num?)?.toInt(),
+  nextPageUrl: json['next_page_url'] as String?,
+  prevPageUrl: json['prev_page_url'] as String?,
+);
+
+Map<String, dynamic> _$DataToJson(Data instance) => <String, dynamic>{
+  'auctions': instance.auctions,
+  'total': instance.total,
+  'current_page': instance.currentPage,
+  'last_page': instance.lastPage,
+  'next_page_url': instance.nextPageUrl,
+  'prev_page_url': instance.prevPageUrl,
 };
 
 MuntahiAction _$MuntahiActionFromJson(Map<String, dynamic> json) =>

--- a/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.dart
+++ b/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.dart
@@ -6,7 +6,7 @@ part 'qadim_auction_response.g.dart';
 class QadimAuctionResponse {
   final bool status;
   final String message;
-  final List<QadimAuction> data;
+  final Data data;
 
   QadimAuctionResponse({
     required this.status,
@@ -20,6 +20,30 @@ class QadimAuctionResponse {
 }
 
 @JsonSerializable()
+class Data {
+  final List<QadimAuction> auctions;
+  final int? total;
+  @JsonKey(name: 'current_page')
+  final int? currentPage;
+  @JsonKey(name: 'last_page')
+  final int? lastPage;
+  @JsonKey(name: 'next_page_url')
+  final String? nextPageUrl;
+  @JsonKey(name: 'prev_page_url')
+  final String? prevPageUrl;
+  Data({
+    required this.auctions,
+    this.total,
+    this.currentPage,
+    this.lastPage,
+    this.nextPageUrl,
+    this.prevPageUrl,
+  });
+  factory Data.fromJson(Map<String, dynamic> json) => _$DataFromJson(json);
+  Map<String, dynamic> toJson() => _$DataToJson(this);
+}
+
+@JsonSerializable()
 class QadimAuction {
   final int id;
   final String slug;
@@ -29,23 +53,23 @@ class QadimAuction {
   final int openingAmount;
 
   @JsonKey(name: 'required_bidders')
-  final int requiredBidders;
+  final int? requiredBidders;
 
   @JsonKey(name: 'registration_amount')
-  final int registrationAmount;
+  final int? registrationAmount;
 
   @JsonKey(name: 'auction_duration_minutes')
   final int? auctionDurationMinutes;
 
   @JsonKey(name: 'auction_start_rate')
-  final int auctionStartRate;
+  final int? auctionStartRate;
 
   @JsonKey(name: 'product_sku')
-  final String productSku;
+  final String? productSku;
 
-  final String type;
+  final String? type;
 
-  final bool isRegister;
+  final bool? isRegister;
 
   final Product product;
 
@@ -54,14 +78,14 @@ class QadimAuction {
     required this.slug,
     required this.status,
     required this.openingAmount,
-    required this.requiredBidders,
-    required this.registrationAmount,
-    required this.auctionDurationMinutes,
-    required this.auctionStartRate,
-    required this.productSku,
-    required this.isRegister,
+    this.requiredBidders,
+    this.registrationAmount,
+    this.auctionDurationMinutes,
+    this.auctionStartRate,
+    this.productSku,
+    this.isRegister,
+    this.type,
     required this.product,
-    required this.type,
   });
 
   factory QadimAuction.fromJson(Map<String, dynamic> json) =>

--- a/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.g.dart
+++ b/lib/feature/home/home_details/qadim/data/model/qadim_auction_response.g.dart
@@ -11,10 +11,7 @@ QadimAuctionResponse _$QadimAuctionResponseFromJson(
 ) => QadimAuctionResponse(
   status: json['status'] as bool,
   message: json['message'] as String,
-  data:
-      (json['data'] as List<dynamic>)
-          .map((e) => QadimAuction.fromJson(e as Map<String, dynamic>))
-          .toList(),
+  data: Data.fromJson(json['data'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$QadimAuctionResponseToJson(
@@ -25,19 +22,40 @@ Map<String, dynamic> _$QadimAuctionResponseToJson(
   'data': instance.data,
 };
 
+Data _$DataFromJson(Map<String, dynamic> json) => Data(
+  auctions:
+      (json['auctions'] as List<dynamic>)
+          .map((e) => QadimAuction.fromJson(e as Map<String, dynamic>))
+          .toList(),
+  total: (json['total'] as num?)?.toInt(),
+  currentPage: (json['current_page'] as num?)?.toInt(),
+  lastPage: (json['last_page'] as num?)?.toInt(),
+  nextPageUrl: json['next_page_url'] as String?,
+  prevPageUrl: json['prev_page_url'] as String?,
+);
+
+Map<String, dynamic> _$DataToJson(Data instance) => <String, dynamic>{
+  'auctions': instance.auctions,
+  'total': instance.total,
+  'current_page': instance.currentPage,
+  'last_page': instance.lastPage,
+  'next_page_url': instance.nextPageUrl,
+  'prev_page_url': instance.prevPageUrl,
+};
+
 QadimAuction _$QadimAuctionFromJson(Map<String, dynamic> json) => QadimAuction(
   id: (json['id'] as num).toInt(),
   slug: json['slug'] as String,
   status: json['status'] as String,
   openingAmount: (json['opening_amount'] as num).toInt(),
-  requiredBidders: (json['required_bidders'] as num).toInt(),
-  registrationAmount: (json['registration_amount'] as num).toInt(),
+  requiredBidders: (json['required_bidders'] as num?)?.toInt(),
+  registrationAmount: (json['registration_amount'] as num?)?.toInt(),
   auctionDurationMinutes: (json['auction_duration_minutes'] as num?)?.toInt(),
-  auctionStartRate: (json['auction_start_rate'] as num).toInt(),
-  productSku: json['product_sku'] as String,
-  isRegister: json['isRegister'] as bool,
+  auctionStartRate: (json['auction_start_rate'] as num?)?.toInt(),
+  productSku: json['product_sku'] as String?,
+  isRegister: json['isRegister'] as bool?,
+  type: json['type'] as String?,
   product: Product.fromJson(json['product'] as Map<String, dynamic>),
-  type: json['type'] as String,
 );
 
 Map<String, dynamic> _$QadimAuctionToJson(QadimAuction instance) =>

--- a/lib/feature/home/home_details/qadim/ui/view/home_details_qadim_screen.dart
+++ b/lib/feature/home/home_details/qadim/ui/view/home_details_qadim_screen.dart
@@ -59,7 +59,7 @@ class HomeDetailsQadimScreen extends StatelessWidget {
                           child: CustomIndcatorItem(
                             title: 'نسبة انطلاق المزاد',
                             showIndicator: true,
-                            value: qadimDetails.auctionStartRate.toInt(),
+                            value: qadimDetails.auctionStartRate?.toInt() ?? 0,
                           ),
                         ),
 
@@ -106,8 +106,11 @@ class HomeDetailsQadimScreen extends StatelessWidget {
 
                           child: CoustomRowItem(
                             title: 'رسوم تنظيم',
-                            price: qadimDetails.registrationAmount
-                                .toStringAsFixed(2),
+                            price:
+                                qadimDetails.registrationAmount != null
+                                    ? qadimDetails.registrationAmount!
+                                        .toStringAsFixed(2)
+                                    : '0.00',
                             style: R.textStyles.font14Grey3W500Light,
                             priceStyle: R.textStyles.font14primaryW500Light,
                           ),
@@ -119,7 +122,7 @@ class HomeDetailsQadimScreen extends StatelessWidget {
                             title: 'انطلاق المزاد',
                             showIndicator: false,
                             style: R.textStyles.font14Grey3W500Light,
-                            value: qadimDetails.auctionStartRate,
+                            value: qadimDetails.auctionStartRate ?? 0,
                           ),
                         ),
                         Container(

--- a/lib/feature/home/home_details/qadim/ui/view/widget/custom_qadim_card_view_item.dart
+++ b/lib/feature/home/home_details/qadim/ui/view/widget/custom_qadim_card_view_item.dart
@@ -92,7 +92,7 @@ class _CustomQadimCardViewItemState extends State<CustomQadimCardViewItem> {
                           CustomIndcatorItem(
                             title: 'انطلاق المزاد',
                             showIndicator: true,
-                            value: widget.qadimDataModel.auctionStartRate,
+                            value: widget.qadimDataModel.auctionStartRate ?? 0,
                           ),
                         ],
                       ),

--- a/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.dart
+++ b/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.dart
@@ -6,7 +6,7 @@ part 'sayantaliq_auction_response.g.dart';
 class SayantaliqAuctionResponse {
   final bool status;
   final String message;
-  final List<SayantaliqAuction> data;
+  final Data data;
 
   SayantaliqAuctionResponse({
     required this.status,
@@ -20,6 +20,30 @@ class SayantaliqAuctionResponse {
   Map<String, dynamic> toJson() => _$SayantaliqAuctionResponseToJson(this);
 }
 
+@JsonSerializable()
+class Data {
+  final List<SayantaliqAuction> auctions;
+  final int? total;
+  @JsonKey(name: 'current_page')
+  final int? currentPage;
+  @JsonKey(name: 'last_page')
+  final int? lastPage;
+  @JsonKey(name: 'next_page_url')
+  final String? nextPageUrl;
+  @JsonKey(name: 'prev_page_url')
+  final String? prevPageUrl;
+  Data({
+    required this.auctions,
+    this.total,
+    this.currentPage,
+    this.lastPage,
+    this.nextPageUrl,
+    this.prevPageUrl,
+  });
+  factory Data.fromJson(Map<String, dynamic> json) => _$DataFromJson(json);
+  Map<String, dynamic> toJson() => _$DataToJson(this);
+}
+
 @JsonSerializable(explicitToJson: true)
 class SayantaliqAuction {
   final int id;
@@ -28,18 +52,18 @@ class SayantaliqAuction {
   @JsonKey(name: 'opening_amount')
   final int openingAmount;
   @JsonKey(name: 'required_bidders')
-  final int requiredBidders;
+  final int? requiredBidders;
   @JsonKey(name: 'registration_amount')
-  final int registrationAmount;
+  final int? registrationAmount;
   @JsonKey(name: 'auction_duration_minutes')
   final int? auctionDurationMinutes;
   @JsonKey(name: 'auction_start_rate')
-  final int auctionStartRate;
+  final int? auctionStartRate;
   @JsonKey(name: 'product_sku')
-  final String productSku;
-  final bool isRegister;
+  final String? productSku;
+  final bool? isRegister;
   @JsonKey(name: 'start_at')
-  final String startAt;
+  final String? startAt;
   final Product product;
 
   SayantaliqAuction({
@@ -47,13 +71,13 @@ class SayantaliqAuction {
     required this.slug,
     required this.status,
     required this.openingAmount,
-    required this.requiredBidders,
-    required this.registrationAmount,
-    required this.auctionDurationMinutes,
-    required this.auctionStartRate,
-    required this.productSku,
-    required this.isRegister,
-    required this.startAt,
+    this.requiredBidders,
+    this.registrationAmount,
+    this.auctionDurationMinutes,
+    this.auctionStartRate,
+    this.productSku,
+    this.isRegister,
+    this.startAt,
     required this.product,
   });
 

--- a/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.g.dart
+++ b/lib/feature/home/home_details/sayantaliq/data/model/sayantaliq_auction_response.g.dart
@@ -11,10 +11,7 @@ SayantaliqAuctionResponse _$SayantaliqAuctionResponseFromJson(
 ) => SayantaliqAuctionResponse(
   status: json['status'] as bool,
   message: json['message'] as String,
-  data:
-      (json['data'] as List<dynamic>)
-          .map((e) => SayantaliqAuction.fromJson(e as Map<String, dynamic>))
-          .toList(),
+  data: Data.fromJson(json['data'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$SayantaliqAuctionResponseToJson(
@@ -22,7 +19,28 @@ Map<String, dynamic> _$SayantaliqAuctionResponseToJson(
 ) => <String, dynamic>{
   'status': instance.status,
   'message': instance.message,
-  'data': instance.data.map((e) => e.toJson()).toList(),
+  'data': instance.data.toJson(),
+};
+
+Data _$DataFromJson(Map<String, dynamic> json) => Data(
+  auctions:
+      (json['auctions'] as List<dynamic>)
+          .map((e) => SayantaliqAuction.fromJson(e as Map<String, dynamic>))
+          .toList(),
+  total: (json['total'] as num?)?.toInt(),
+  currentPage: (json['current_page'] as num?)?.toInt(),
+  lastPage: (json['last_page'] as num?)?.toInt(),
+  nextPageUrl: json['next_page_url'] as String?,
+  prevPageUrl: json['prev_page_url'] as String?,
+);
+
+Map<String, dynamic> _$DataToJson(Data instance) => <String, dynamic>{
+  'auctions': instance.auctions,
+  'total': instance.total,
+  'current_page': instance.currentPage,
+  'last_page': instance.lastPage,
+  'next_page_url': instance.nextPageUrl,
+  'prev_page_url': instance.prevPageUrl,
 };
 
 SayantaliqAuction _$SayantaliqAuctionFromJson(Map<String, dynamic> json) =>
@@ -31,14 +49,14 @@ SayantaliqAuction _$SayantaliqAuctionFromJson(Map<String, dynamic> json) =>
       slug: json['slug'] as String,
       status: json['status'] as String,
       openingAmount: (json['opening_amount'] as num).toInt(),
-      requiredBidders: (json['required_bidders'] as num).toInt(),
-      registrationAmount: (json['registration_amount'] as num).toInt(),
+      requiredBidders: (json['required_bidders'] as num?)?.toInt(),
+      registrationAmount: (json['registration_amount'] as num?)?.toInt(),
       auctionDurationMinutes:
           (json['auction_duration_minutes'] as num?)?.toInt(),
-      auctionStartRate: (json['auction_start_rate'] as num).toInt(),
-      productSku: json['product_sku'] as String,
-      isRegister: json['isRegister'] as bool,
-      startAt: json['start_at'] as String,
+      auctionStartRate: (json['auction_start_rate'] as num?)?.toInt(),
+      productSku: json['product_sku'] as String?,
+      isRegister: json['isRegister'] as bool?,
+      startAt: json['start_at'] as String?,
       product: Product.fromJson(json['product'] as Map<String, dynamic>),
     );
 

--- a/lib/feature/home/home_details/sayantaliq/ui/view/widget/custom_sayantaliq_cart_virew_item.dart
+++ b/lib/feature/home/home_details/sayantaliq/ui/view/widget/custom_sayantaliq_cart_virew_item.dart
@@ -29,7 +29,7 @@ class _CustomQadimCardViewItemState
   @override
   Widget build(BuildContext context) {
     DateTime eventTimeFromApi = DateTime.parse(
-      widget.sayantaliqDataModel.startAt,
+      widget.sayantaliqDataModel.startAt ?? DateTime.now().toIso8601String(),
     );
 
     return SingleChildScrollView(

--- a/lib/feature/home/ui/view/widget/custom_tap_view.dart
+++ b/lib/feature/home/ui/view/widget/custom_tap_view.dart
@@ -94,7 +94,16 @@ class _CustomTapViewState extends State<CustomTapView>
                     if (state is QadimLoading) {
                       return const Center(child: CircularProgressIndicator());
                     } else if (state is QadimError) {
-                      return Center(child: Text(state.errorMessage));
+                      return RefreshIndicator(
+                        onRefresh:
+                            () =>
+                                context
+                                    .read<QadimCubit>()
+                                    .getNotStartAuctions(),
+                        child: ListView(
+                          children: [Center(child: Text(state.errorMessage))],
+                        ),
+                      );
                     } else if (state is QadimSuccess) {
                       final qadimAuctionResponse = state.data;
                       return RefreshIndicator(
@@ -107,13 +116,13 @@ class _CustomTapViewState extends State<CustomTapView>
                           physics: const AlwaysScrollableScrollPhysics(),
                           padding: EdgeInsets.zero,
 
-                          itemCount: qadimAuctionResponse.data.length,
+                          itemCount: qadimAuctionResponse.data.auctions.length,
                           itemBuilder: (context, index) {
                             return Padding(
                               padding: const EdgeInsets.only(bottom: 16.0),
                               child: CustomQadimCardViewItem(
                                 qadimDataModel:
-                                    qadimAuctionResponse.data[index],
+                                    qadimAuctionResponse.data.auctions[index],
                               ),
                             );
                           },
@@ -132,19 +141,31 @@ class _CustomTapViewState extends State<CustomTapView>
                     if (state is SayantaliqLoading) {
                       return const Center(child: CircularProgressIndicator());
                     } else if (state is SayantaliqError) {
-                      return Center(child: Text(state.errorMessage));
+                      return RefreshIndicator(
+                        onRefresh:
+                            () =>
+                                context
+                                    .read<SayantaliqCubit>()
+                                    .getReadyAuctions(),
+                        child: ListView(
+                          children: [Center(child: Text(state.errorMessage))],
+                        ),
+                      );
                     } else if (state is SayantaliqSuccess) {
                       final sayantaliqAuctionResponse = state.data;
                       return ListView.builder(
                         padding: EdgeInsets.zero,
 
-                        itemCount: sayantaliqAuctionResponse.data.length,
+                        itemCount:
+                            sayantaliqAuctionResponse.data.auctions.length,
                         itemBuilder: (context, index) {
                           return Padding(
                             padding: const EdgeInsets.only(bottom: 16.0),
                             child: CustomSayantaliqCardViewItem(
                               sayantaliqDataModel:
-                                  sayantaliqAuctionResponse.data[index],
+                                  sayantaliqAuctionResponse
+                                      .data
+                                      .auctions[index],
                             ),
                           );
                         },
@@ -163,18 +184,26 @@ class _CustomTapViewState extends State<CustomTapView>
                     if (state is JaraaLoading) {
                       return const Center(child: CircularProgressIndicator());
                     } else if (state is JaraaError) {
-                      return Center(child: Text(state.errorMessage));
+                      return RefreshIndicator(
+                        onRefresh:
+                            () =>
+                                context.read<JaraaCubit>().getOngoingAuctions(),
+                        child: ListView(
+                          children: [Center(child: Text(state.errorMessage))],
+                        ),
+                      );
                     } else if (state is JaraaSuccess) {
                       final jaraaAuctionResponse = state.data;
                       return ListView.builder(
                         padding: EdgeInsets.zero,
 
-                        itemCount: jaraaAuctionResponse.data.length,
+                        itemCount: jaraaAuctionResponse.data.auctions.length,
                         itemBuilder: (context, index) {
                           return Padding(
                             padding: const EdgeInsets.only(bottom: 16.0),
                             child: CustomJaraaCardViewItem(
-                              jaraaDataModel: jaraaAuctionResponse.data[index],
+                              jaraaDataModel:
+                                  jaraaAuctionResponse.data.auctions[index],
                             ),
                           );
                         },
@@ -192,19 +221,28 @@ class _CustomTapViewState extends State<CustomTapView>
                     if (state is MuntahiLoading) {
                       return const Center(child: CircularProgressIndicator());
                     } else if (state is MuntahiError) {
-                      return Center(child: Text(state.errorMessage));
+                      return RefreshIndicator(
+                        onRefresh:
+                            () =>
+                                context
+                                    .read<MuntahiCubit>()
+                                    .getFinishedAuctions(),
+                        child: ListView(
+                          children: [Center(child: Text(state.errorMessage))],
+                        ),
+                      );
                     } else if (state is MuntahiSuccess) {
                       final muntaliAuctionResponse = state.data;
                       return ListView.builder(
                         padding: EdgeInsets.zero,
 
-                        itemCount: muntaliAuctionResponse.data.length,
+                        itemCount: muntaliAuctionResponse.data.auctions.length,
                         itemBuilder: (context, index) {
                           return Padding(
                             padding: const EdgeInsets.only(bottom: 16.0),
                             child: CustomMuntahiCardViewItem(
                               muntahiDataModel:
-                                  muntaliAuctionResponse.data[index],
+                                  muntaliAuctionResponse.data.auctions[index],
                             ),
                           );
                         },

--- a/lib/feature/profile/view/profile_screen.dart
+++ b/lib/feature/profile/view/profile_screen.dart
@@ -56,12 +56,23 @@ class ProfileScreen extends StatelessWidget {
                   ],
                 );
               } else if (state is UserDataError) {
-                return Column(
-                  children: [
-                    SizedBox(height: 200),
-                    Center(child: Text('حدث خطأ: ${state.errMessage}')),
-                    CustomLogoutBotton(),
-                  ],
+                return RefreshIndicator(
+                  onRefresh: () async {
+                    context.read<UserDataCubit>().fetchUserData();
+                  },
+                  child: ListView(
+                    shrinkWrap: true,
+                    children: [
+                      Column(
+                        children: [
+                          SizedBox(height: 200.h),
+                          Center(child: Text('حدث خطأ: ${state.errMessage}')),
+                          SizedBox(height: 20.h),
+                          CustomLogoutBotton(),
+                        ],
+                      ),
+                    ],
+                  ),
                 );
               } else {
                 return const SizedBox.shrink();


### PR DESCRIPTION
- Refactor auction response models to include a `Data` wrapper for consistent pagination data.
- Update Qadim, Sayantaliq, Jaraa, and Muntahi auction response models and related generated files to reflect the new `Data` structure.
- Modify `CustomTapView` to access auction lists from the `Data` wrapper in the response models.
- Implement `RefreshIndicator` and `ListView` for error states in `CustomTapView` to allow users to retry loading data.
- Handle null values for `auctionStartRate` and `registrationAmount` in `CustomQadimCardViewItem` and `HomeDetailsQadimScreen` to prevent errors.
- Provide a default value for `startAt` in `CustomSayantaliqCardViewItem` to prevent parsing errors when the API returns null.
- Implement `RefreshIndicator` for `UserDataError` state in `ProfileScreen` to allow users to retry fetching user data.