### PR TITLE
fix: Update progress indicator value and Xcode version

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1610;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/feature/home/ui/view/widget/custom_indcator_item.dart
+++ b/lib/feature/home/ui/view/widget/custom_indcator_item.dart
@@ -42,7 +42,7 @@ class CustomIndcatorItem extends StatelessWidget {
                   child: LinearProgressIndicator(
                     minHeight: 8.h,
                     borderRadius: BorderRadius.circular(99),
-                    value: 0.5,
+                    value: value / 100,
                     backgroundColor: R.colors.colorUnSelected,
                     color: R.colors.primaryColorLight,
                   ),


### PR DESCRIPTION
This commit addresses two issues:

- Updates the value of the linear progress indicator in `CustomIndcatorItem` to correctly represent the percentage value. The value is now calculated as `value / 100` instead of being hardcoded to `0.5`.
- Updates the `LastUpgradeCheck` value in the Xcode project files (`Runner.xcscheme` and `project.pbxproj`) from `1610` to `1510`. This aligns the project with the Xcode 15.1.0.